### PR TITLE
Register Haiku 4.5 model in chat worker

### DIFF
--- a/worker/chat-api/worker.js
+++ b/worker/chat-api/worker.js
@@ -164,6 +164,19 @@ function createChunkTransformer() {
   });
 }
 
+// ── Available Anthropic models ───────────────────────────────────────────────
+// Selected via the MODEL env var (defaults to 'sonnet'). Add new models here.
+export const MODELS = {
+  sonnet: 'claude-sonnet-4-20250514',
+  haiku: 'claude-haiku-4-5-20251001',
+};
+const DEFAULT_MODEL_KEY = 'sonnet';
+
+export function resolveModel(env) {
+  const key = (env.MODEL || DEFAULT_MODEL_KEY).toLowerCase();
+  return MODELS[key] || MODELS[DEFAULT_MODEL_KEY];
+}
+
 // ── Main handler ─────────────────────────────────────────────────────────────
 export default {
   async fetch(request, env) {
@@ -232,7 +245,7 @@ export default {
           'x-api-key': apiKey,
         },
         body: JSON.stringify({
-          model: 'claude-sonnet-4-20250514',
+          model: resolveModel(env),
           max_tokens: 1024,
           system: SYSTEM_PROMPT,
           messages: body.messages,

--- a/worker/chat-api/worker.test.js
+++ b/worker/chat-api/worker.test.js
@@ -1,6 +1,6 @@
 import test from 'node:test';
 import assert from 'node:assert/strict';
-import { validateRequest, isRateLimited, _resetRateMap } from './worker.js';
+import { validateRequest, isRateLimited, _resetRateMap, resolveModel, MODELS } from './worker.js';
 
 test('validateRequest rejects missing/empty messages', () => {
   assert.equal(validateRequest({}, 50).ok, false);
@@ -46,4 +46,21 @@ test('isRateLimited treats different IPs independently', () => {
   assert.equal(isRateLimited('a', 1), false);
   assert.equal(isRateLimited('a', 1), true);
   assert.equal(isRateLimited('b', 1), false);
+});
+
+test('resolveModel defaults to sonnet when MODEL is unset', () => {
+  assert.equal(resolveModel({}), MODELS.sonnet);
+});
+
+test('resolveModel selects haiku when MODEL=haiku', () => {
+  assert.equal(resolveModel({ MODEL: 'haiku' }), MODELS.haiku);
+  assert.equal(resolveModel({ MODEL: 'HAIKU' }), MODELS.haiku);
+});
+
+test('resolveModel falls back to sonnet for unknown keys', () => {
+  assert.equal(resolveModel({ MODEL: 'opus' }), MODELS.sonnet);
+});
+
+test('MODELS contains the latest Haiku 4.5 ID', () => {
+  assert.equal(MODELS.haiku, 'claude-haiku-4-5-20251001');
 });

--- a/worker/chat-api/wrangler.toml
+++ b/worker/chat-api/wrangler.toml
@@ -9,3 +9,5 @@ routes = [
 ALLOWED_ORIGIN = "https://kinokoholic.com"
 MAX_MESSAGES = 50
 RATE_LIMIT_PER_HOUR = 30
+# MODEL keys are defined in worker.js MODELS (currently: "sonnet", "haiku").
+MODEL = "sonnet"


### PR DESCRIPTION
## Summary

Adds `claude-haiku-4-5-20251001` (Haiku 4.5) to the chat worker as a selectable model alongside the existing Sonnet pin.

## What changed

- `worker/chat-api/worker.js`
  - New `MODELS` map: `{ sonnet: 'claude-sonnet-4-20250514', haiku: 'claude-haiku-4-5-20251001' }`
  - New `resolveModel(env)` reads `env.MODEL` (case-insensitive), falls back to `sonnet` for unknown keys
  - The Anthropic call now uses `resolveModel(env)` instead of a hardcoded ID
- `worker/chat-api/wrangler.toml`
  - Adds `MODEL = "sonnet"` to `[vars]` with a comment listing valid keys
- `worker/chat-api/worker.test.js`
  - 4 new tests: default selection, haiku selection, case-insensitivity, fallback for unknown keys, and a pin assertion on the Haiku 4.5 ID

## Behavior

Default behavior is unchanged — `MODEL` defaults to `sonnet` and resolves to the same model ID main is using today. Switching to Haiku is now a one-line `wrangler.toml` change (or a Workers env override) instead of a code edit.

## Test plan

- [x] `npm run check` (worker) — passes
- [x] `npm test` (worker) — 10/10 pass
- [ ] Deploy to a staging Worker with `MODEL=haiku` and confirm streaming works end-to-end

---
_Generated by [Claude Code](https://claude.ai/code/session_01X79m9uZaQdSz5rUGgqYYZB)_