### PR TITLE
Fix chat streaming: Uint8Array → string decoding before SSE parse

### DIFF
--- a/worker/chat-api/worker.js
+++ b/worker/chat-api/worker.js
@@ -131,31 +131,38 @@ export function validateRequest(body, maxMessages) {
   return { ok: true };
 }
 
+// ── SSE parsing ──────────────────────────────────────────────────────────────
+// Exported for unit tests. Accepts a decoded string chunk, returns text tokens.
+export function parseSSEChunk(chunk) {
+  const tokens = [];
+  for (const line of chunk.split('\n')) {
+    const trimmed = line.trim();
+    if (!trimmed.startsWith('data: ')) continue;
+    const data = trimmed.slice(6);
+    if (!data || data === '[DONE]') continue;
+    try {
+      const parsed = JSON.parse(data);
+      if (parsed.type === 'content_block_delta' && parsed.delta?.type === 'text_delta' && parsed.delta.text != null) {
+        tokens.push(parsed.delta.text);
+      }
+    } catch { /* skip malformed */ }
+  }
+  return tokens;
+}
+
 // ── Stream transformer: Anthropic SSE → client chunks ────────────────────────
 function createChunkTransformer() {
   let buffer = '';
   return new TransformStream({
     transform(chunk, controller) {
+      // chunk is already a decoded string (TextDecoderStream runs before this)
       buffer += chunk;
       const lines = buffer.split('\n');
       buffer = lines.pop(); // keep incomplete line in buffer
 
-      for (const line of lines) {
-        const trimmed = line.trim();
-        if (!trimmed.startsWith('data: ')) continue;
-        const data = trimmed.slice(6);
-        if (data === '[DONE]') continue;
-
-        try {
-          const parsed = JSON.parse(data);
-          // Anthropic streaming event types
-          if (parsed.type === 'content_block_delta' && parsed.delta?.text) {
-            const payload = JSON.stringify({ text: parsed.delta.text });
-            controller.enqueue(new TextEncoder().encode(`data: ${payload}\n\n`));
-          }
-        } catch {
-          // skip malformed JSON
-        }
+      for (const token of parseSSEChunk(lines.join('\n') + '\n')) {
+        const payload = JSON.stringify({ text: token });
+        controller.enqueue(new TextEncoder().encode(`data: ${payload}\n\n`));
       }
     },
     flush(controller) {
@@ -262,9 +269,11 @@ export default {
         );
       }
 
-      // Stream Anthropic SSE through our transformer to the client
+      // Stream Anthropic SSE through our transformer to the client.
+      // TextDecoderStream converts Uint8Array chunks → strings before parsing.
       const { readable, writable } = new TransformStream();
       response.body
+        .pipeThrough(new TextDecoderStream())
         .pipeThrough(createChunkTransformer())
         .pipeTo(writable)
         .catch((err) => console.error('Stream pipe error:', err));

--- a/worker/chat-api/worker.test.js
+++ b/worker/chat-api/worker.test.js
@@ -1,6 +1,6 @@
 import test from 'node:test';
 import assert from 'node:assert/strict';
-import { validateRequest, isRateLimited, _resetRateMap, resolveModel, MODELS } from './worker.js';
+import { validateRequest, isRateLimited, _resetRateMap, resolveModel, MODELS, parseSSEChunk } from './worker.js';
 
 test('validateRequest rejects missing/empty messages', () => {
   assert.equal(validateRequest({}, 50).ok, false);
@@ -63,4 +63,30 @@ test('resolveModel falls back to sonnet for unknown keys', () => {
 
 test('MODELS contains the latest Haiku 4.5 ID', () => {
   assert.equal(MODELS.haiku, 'claude-haiku-4-5-20251001');
+});
+
+test('parseSSEChunk extracts text_delta text from Anthropic streaming event', () => {
+  const event = JSON.stringify({
+    type: 'content_block_delta',
+    index: 0,
+    delta: { type: 'text_delta', text: 'Hello' },
+  });
+  const result = parseSSEChunk(`data: ${event}\n`);
+  assert.deepEqual(result, ['Hello']);
+});
+
+test('parseSSEChunk skips non-text_delta events', () => {
+  const event = JSON.stringify({ type: 'message_start', message: {} });
+  const result = parseSSEChunk(`data: ${event}\n`);
+  assert.deepEqual(result, []);
+});
+
+test('parseSSEChunk handles empty string delta without crashing', () => {
+  const event = JSON.stringify({
+    type: 'content_block_delta',
+    index: 0,
+    delta: { type: 'text_delta', text: '' },
+  });
+  const result = parseSSEChunk(`data: ${event}\n`);
+  assert.deepEqual(result, ['']);
 });


### PR DESCRIPTION
## Root cause

`response.body` from the Anthropic fetch provides `Uint8Array` chunks. The SSE transformer was doing `buffer += chunk` directly — in V8, that calls `Uint8Array.toString()` which produces comma-separated byte values (`"72,101,108,108,111"`) instead of text. The SSE parser never found any `data:` lines, so no tokens were forwarded to the client and the chat appeared to think then go silent.

## Fix

Pipe `response.body` through `new TextDecoderStream()` before the custom transformer, so it receives proper UTF-8 strings:

```js
response.body
  .pipeThrough(new TextDecoderStream())  // ← added
  .pipeThrough(createChunkTransformer())
  .pipeTo(writable)
```

## Also

- Tighten delta check: require `delta.type === 'text_delta'` (per Anthropic streaming spec) and use `!= null` instead of truthiness so empty-string tokens are forwarded.
- Extract `parseSSEChunk()` as a named export and add 3 unit tests for it.

## Test plan

- [x] `npm run check && npm test` — 13/13 pass
- [ ] Deploy to Worker and confirm messages stream end-to-end in `/chat/`

---
_Generated by [Claude Code](https://claude.ai/code/session_01X79m9uZaQdSz5rUGgqYYZB)_