### PR TITLE
Bump Sonnet to 4.6 (claude-sonnet-4-6)

### DIFF
--- a/worker/chat-api/worker.js
+++ b/worker/chat-api/worker.js
@@ -174,7 +174,7 @@ function createChunkTransformer() {
 // ── Available Anthropic models ───────────────────────────────────────────────
 // Selected via the MODEL env var (defaults to 'sonnet'). Add new models here.
 export const MODELS = {
-  sonnet: 'claude-sonnet-4-20250514',
+  sonnet: 'claude-sonnet-4-6',
   haiku: 'claude-haiku-4-5-20251001',
 };
 const DEFAULT_MODEL_KEY = 'sonnet';


### PR DESCRIPTION
Bumps the registered Sonnet model from `claude-sonnet-4-20250514` (Sonnet 4.0, May 2024) to `claude-sonnet-4-6` (current Sonnet 4.6).

Haiku stays on `claude-haiku-4-5-20251001` (Haiku 4.5).

## Test plan

- [x] `cd worker/chat-api && npm run check && npm test` — 13/13 pass
- [ ] Deploy and confirm `/chat/` still responds
- [ ] Optionally test `MODEL=haiku` deploy via `wrangler.toml`

---
_Generated by [Claude Code](https://claude.ai/code/session_01X79m9uZaQdSz5rUGgqYYZB)_