### PR TITLE
Add chat CTA to homepage + persona starter questions in chat

### DIFF
--- a/assets/css/chat.css
+++ b/assets/css/chat.css
@@ -56,17 +56,52 @@ footer {
   scroll-behavior: smooth;
 }
 
-/* Empty state */
-.chat-empty {
-  display: flex;
-  align-items: center;
-  justify-content: center;
-  height: 100%;
+/* ── Starter questions ──────────────────────────────────────────────── */
+.chat-starters {
+  padding: 16px 0 8px;
+}
+
+.chat-starters__intro {
   color: var(--muted, #5e6b7d);
-  font-size: 1rem;
-  text-align: center;
-  padding: 40px;
-  line-height: 1.6;
+  font-size: 0.9rem;
+  margin: 0 0 20px;
+  line-height: 1.5;
+}
+
+.chat-starters__group {
+  margin-bottom: 18px;
+}
+
+.chat-starters__label {
+  display: block;
+  font-size: 0.72rem;
+  font-weight: 600;
+  letter-spacing: 0.07em;
+  text-transform: uppercase;
+  color: var(--muted, #5e6b7d);
+  margin-bottom: 8px;
+}
+
+.chat-starter-btn {
+  display: block;
+  width: 100%;
+  text-align: left;
+  background: var(--surface, #ffffff);
+  border: 1px solid var(--line, #d4e0ec);
+  border-radius: var(--radius-sm, 10px);
+  padding: 10px 14px;
+  font-family: "IBM Plex Sans", system-ui, sans-serif;
+  font-size: 0.88rem;
+  color: var(--ink, #162130);
+  cursor: pointer;
+  margin-bottom: 6px;
+  transition: border-color 0.15s ease, background 0.15s ease;
+  line-height: 1.45;
+}
+.chat-starter-btn:hover {
+  border-color: var(--brand, #0f5f80);
+  background: var(--accent, #e4f0fa);
+  color: var(--brand, #0f5f80);
 }
 
 /* Message row */

--- a/assets/js/chat.js
+++ b/assets/js/chat.js
@@ -68,14 +68,67 @@
     renderAll();
   }
 
+  // ── Starter questions ────────────────────────────────────────────────
+  const STARTER_GROUPS = [
+    {
+      label: 'Recruiter',
+      questions: [
+        "What's David's current availability and the type of roles he's open to?",
+        "What's his strongest end-to-end project — from problem to production?",
+        "How does his PM background change the way he builds AI systems?",
+      ],
+    },
+    {
+      label: 'Business partner',
+      questions: [
+        "What kind of engagements does David take on?",
+        "How would he scope and approach a RAG or agentic workflow project?",
+        "What's a realistic timeline and process for an AI-powered product MVP?",
+      ],
+    },
+    {
+      label: 'Startup founder',
+      questions: [
+        "Can you walk me through the -mon product family and what it's building toward?",
+        "What would David build differently if he were starting the JTES project over?",
+        "How does he decide when to ship vs. keep iterating?",
+      ],
+    },
+  ];
+
+  function renderStarterQuestions() {
+    const wrap = document.createElement('div');
+    wrap.className = 'chat-starters';
+    wrap.innerHTML = `<p class="chat-starters__intro">Ask me anything about David's work, or pick a question below.</p>`;
+
+    STARTER_GROUPS.forEach(group => {
+      const section = document.createElement('div');
+      section.className = 'chat-starters__group';
+      section.innerHTML = `<span class="chat-starters__label">${escapeHtml(group.label)}</span>`;
+
+      group.questions.forEach(q => {
+        const btn = document.createElement('button');
+        btn.className = 'chat-starter-btn';
+        btn.textContent = q;
+        btn.addEventListener('click', () => {
+          inputEl.value = q;
+          autoResize();
+          handleSend();
+        });
+        section.appendChild(btn);
+      });
+
+      wrap.appendChild(section);
+    });
+
+    messagesEl.appendChild(wrap);
+  }
+
   // ── Render ──────────────────────────────────────────────────────────
   function renderAll() {
     messagesEl.innerHTML = '';
     if (messages.length === 0) {
-      messagesEl.innerHTML = `
-        <div class="chat-empty">
-          Ask me anything about David's work — projects, tradeoffs, scope, what he'd do differently.
-        </div>`;
+      renderStarterQuestions();
       return;
     }
     messages.forEach(msg => appendMessage(msg.role, msg.content));
@@ -83,8 +136,7 @@
   }
 
   function appendMessage(role, content) {
-    // Remove empty state if present
-    const empty = messagesEl.querySelector('.chat-empty');
+    const empty = messagesEl.querySelector('.chat-empty, .chat-starters');
     if (empty) empty.remove();
 
     const row = document.createElement('div');

--- a/i18n/strings.ja.json
+++ b/i18n/strings.ja.json
@@ -232,7 +232,7 @@
     "connect.modlabel": "// CONNECT",
     "connect.h2": "ポートフォリオを掘りたい? まずはエージェントに聞いてください。",
     "connect.lead": "プロジェクト・トレードオフ・範囲・やり直すなら何を変えるか。Kinokomonに何でも聞いてから、ゆっくりしたチャネルで連絡を。",
-    "connect.cta": "▸ Kinokomonサンドボックスを開く",
+    "connect.cta": "▸ AIアシスタントに聞く",
     "connect.email_k": "メール",
     "connect.gh_k": "github",
     "connect.li_k": "linkedin",

--- a/index.html
+++ b/index.html
@@ -517,7 +517,7 @@
         <h2 style="margin-top:.7rem" data-i18n="connect.h2">Want to interrogate the portfolio? Talk to my agent first.</h2>
         <p style="margin-top:.7rem" data-i18n="connect.lead">Ask Kinokomon anything about the work — projects, tradeoffs, scope, what I'd do differently. Then come find me on the slow channels.</p>
         <p style="margin-top:1.4rem">
-          <a class="chip chip--brand" href="/kinokomon/" data-i18n="connect.cta">▸ open kinokomon sandbox</a>
+          <a class="chip chip--brand" href="/chat/" data-i18n="connect.cta">▸ ask the AI assistant</a>
         </p>
       </div>
       <div class="connect__channels" data-fade>

--- a/tests/js/chat.test.js
+++ b/tests/js/chat.test.js
@@ -62,3 +62,50 @@ test('message shape validation accepts valid roles only', () => {
   assert.equal(isValidMessage({}), false);
   assert.equal(isValidMessage(null), false);
 });
+
+// ── Starter questions data ──────────────────────────────────────────
+// Mirrors STARTER_GROUPS in assets/js/chat.js — update both together.
+const STARTER_GROUPS = [
+  {
+    label: 'Recruiter',
+    questions: [
+      "What's David's current availability and the type of roles he's open to?",
+      "What's his strongest end-to-end project — from problem to production?",
+      "How does his PM background change the way he builds AI systems?",
+    ],
+  },
+  {
+    label: 'Business partner',
+    questions: [
+      "What kind of engagements does David take on?",
+      "How would he scope and approach a RAG or agentic workflow project?",
+      "What's a realistic timeline and process for an AI-powered product MVP?",
+    ],
+  },
+  {
+    label: 'Startup founder',
+    questions: [
+      "Can you walk me through the -mon product family and what it's building toward?",
+      "What would David build differently if he were starting the JTES project over?",
+      "How does he decide when to ship vs. keep iterating?",
+    ],
+  },
+];
+
+test('starter groups have 3 personas each with at least 3 non-empty questions', () => {
+  assert.equal(STARTER_GROUPS.length, 3);
+  for (const group of STARTER_GROUPS) {
+    assert.ok(typeof group.label === 'string' && group.label.length > 0, `${group.label} has a label`);
+    assert.ok(group.questions.length >= 3, `${group.label} has at least 3 questions`);
+    for (const q of group.questions) {
+      assert.ok(typeof q === 'string' && q.trim().length > 0, `question is non-empty string`);
+    }
+  }
+});
+
+test('starter group labels cover the expected personas', () => {
+  const labels = STARTER_GROUPS.map(g => g.label);
+  assert.ok(labels.includes('Recruiter'));
+  assert.ok(labels.includes('Business partner'));
+  assert.ok(labels.includes('Startup founder'));
+});


### PR DESCRIPTION
## What's included

**Homepage** (`index.html`, `i18n/strings.ja.json`)
- The `/connect` section CTA now links to `/chat/` instead of `/kinokomon/`
- EN: "▸ ask the AI assistant" / JA: "▸ AIアシスタントに聞く"

**Chat interface** (`assets/js/chat.js`, `assets/css/chat.css`)
- Empty state replaced with persona-grouped one-click starter buttons
- Three groups with 3 questions each:

| Persona | Sample question |
|---|---|
| Recruiter | "What's his strongest end-to-end project — from problem to production?" |
| Business partner | "How would he scope and approach a RAG or agentic workflow project?" |
| Startup founder | "What would David build differently if he were starting the JTES project over?" |

- Clicking a button pre-fills the input and immediately sends — no extra tap needed
- Starters dismiss as soon as the first message is appended

## Test plan
- [ ] Homepage `/connect` section CTA links to `/chat/`
- [ ] `/chat/` loads with three labelled question groups
- [ ] Clicking a starter button sends the message and dismisses the panel
- [ ] Typing your own message also dismisses the starters on send

---
_Generated by [Claude Code](https://claude.ai/code/session_01X79m9uZaQdSz5rUGgqYYZB)_