### PR TITLE
fix(home): evenly distribute -MON family cards

### DIFF
--- a/assets/css/site.css
+++ b/assets/css/site.css
@@ -703,7 +703,7 @@ code, .mono, .label {
 /* ============ -mon family ============ */
 .mon-grid {
   display: grid;
-  grid-template-columns: repeat(4, 1fr);
+  grid-template-columns: repeat(auto-fit, minmax(180px, 1fr));
   gap: 0.9rem;
 }
 .mon-card {
@@ -1125,7 +1125,6 @@ code, .mono, .label {
   .stack-strip { grid-template-columns: repeat(3, 1fr); }
   .stack-cell:nth-child(3) { border-right: none; }
   .recipes, .articles, .gh-grid { grid-template-columns: repeat(2, 1fr); }
-  .mon-grid { grid-template-columns: repeat(2, 1fr); }
 }
 @media (max-width: 820px) {
   .hero__grid { grid-template-columns: 1fr; }


### PR DESCRIPTION
The family grid was a fixed 4-column desktop layout, so the 5th card (Keibamon) orphaned onto its own row. Switch .mon-grid to repeat(auto-fit, minmax(180px, 1fr)) so the cards always fill the row evenly regardless of how many family agents exist, and drop the fixed 2-column tablet override so auto-fit governs that band too.

## Summary
- 

## TDD Checklist
- [ ] I wrote or updated failing tests first (Red)
- [ ] I implemented the minimum code to pass tests (Green)
- [ ] I refactored while keeping tests green (Refactor)
- [ ] Source changes include corresponding test file changes in this PR
- [ ] `worker` checks pass (`npm run check && npm test`) when worker code changed
- [ ] Jekyll build passes for relevant site changes

## Risk Notes
- 
