### PR TITLE
Reciprocal link: point Keibamon -MON card to keibamon.com

### DIFF
--- a/index.html
+++ b/index.html
@@ -343,7 +343,7 @@
           <span class="mon-card__tag" data-i18n="fam.ke.tag">healthcare</span>
         </div>
       </a>
-      <a class="mon-card" href="https://github.com/davidklan-png/keibamon" target="_blank" rel="noreferrer" data-fade>
+      <a class="mon-card" href="https://keibamon.com" target="_blank" rel="noreferrer" data-fade>
         <div class="mon-card__art"><img src="assets/images/keibamon.png" alt="Keibamon"></div>
         <div class="mon-card__body">
           <div class="mon-card__name">Keibamon <span class="mon-card__ja">競馬モン</span></div>

--- a/shared/profile.json
+++ b/shared/profile.json
@@ -53,7 +53,7 @@
       "name": "Keibamon",
       "name_ja": "競馬モン",
       "icon": "keibamon.png",
-      "href": "https://github.com/davidklan-png/keibamon",
+      "href": "https://keibamon.com",
       "external": true,
       "desc_en": "Local-first horse-racing data & ML platform. Medallion lake, odds polling, backtesting engine, JRA/NAR race analysis.",
       "tag_en": "racing · ML",


### PR DESCRIPTION
keibamon.com (splash) links to kinokoholic.com; link back the other way. Update mon_family[kb].href github -> keibamon.com in shared/profile.json and regenerate the homepage grid via scripts/sync_mon_family.py. GitHub remains reachable from the keibamon.com splash.

## Summary
- 

## TDD Checklist
- [ ] I wrote or updated failing tests first (Red)
- [ ] I implemented the minimum code to pass tests (Green)
- [ ] I refactored while keeping tests green (Refactor)
- [ ] Source changes include corresponding test file changes in this PR
- [ ] `worker` checks pass (`npm run check && npm test`) when worker code changed
- [ ] Jekyll build passes for relevant site changes

## Risk Notes
- 
