### PR TITLE
Point Dazbeez Receipts CTA to contact form instead of mailto

### DIFF
--- a/_data/projects/receipt_classification_matching.yml
+++ b/_data/projects/receipt_classification_matching.yml
@@ -29,7 +29,7 @@ splash:
   summary: A photo-first receipt workflow that keeps capture effortless, runs vision extraction locally, assists AMEX reconciliation, and produces a retention-aware accountant package.
   status: Private module · public case study
   primary_cta: Request a private walkthrough
-  primary_cta_url: "mailto:admin@dazbeez.com?subject=Dazbeez%20Receipts%20walkthrough"
+  primary_cta_url: "https://dazbeez.com/contact?message=Hi+David%2C+I%27d+like+a+private+walkthrough+of+Dazbeez+Receipts%2C+including+the+capture%2C+review%2C+AMEX+reconciliation%2C+compliance%2C+and+accountant+export+workflow."
   secondary_cta: View the source on GitHub
   secondary_cta_url: https://github.com/davidklan-png/dazbeez
   privacy_note: The live application is Clerk-protected and noindexed. Every interface shown here uses synthetic data.
@@ -161,7 +161,7 @@ splash_ja:
   summary: 写真優先の取り込み、ローカル画像AI、AMEX突合支援、保管要件に対応した会計士向けパッケージを、一つのワークフローにまとめます。
   status: 非公開モジュール · 公開ケーススタディ
   primary_cta: 個別ウォークスルーを依頼
-  primary_cta_url: "mailto:admin@dazbeez.com?subject=Dazbeez%20Receipts%20walkthrough"
+  primary_cta_url: "https://dazbeez.com/contact?message=Dazbeez+Receipts%E3%81%AE%E5%80%8B%E5%88%A5%E3%82%A6%E3%82%A9%E3%83%BC%E3%82%AF%E3%82%B9%E3%83%AB%E3%83%BC%E3%82%92%E5%B8%8C%E6%9C%9B%E3%81%97%E3%81%BE%E3%81%99%E3%80%82%E5%8F%96%E3%82%8A%E8%BE%BC%E3%81%BF%E3%80%81%E3%83%AC%E3%83%93%E3%83%A5%E3%83%BC%E3%80%81AMEX%E7%AA%81%E5%90%88%E3%80%81%E3%82%B3%E3%83%B3%E3%83%97%E3%83%A9%E3%82%A4%E3%82%A2%E3%83%B3%E3%82%B9%E3%80%81%E4%BC%9A%E8%A8%88%E5%A3%AB%E5%90%91%E3%81%91%E3%82%A8%E3%82%AF%E3%82%B9%E3%83%9D%E3%83%BC%E3%83%88%E3%81%AE%E6%B5%81%E3%82%8C%E3%82%92%E8%A9%B3%E3%81%97%E3%81%8F%E7%9F%A5%E3%82%8A%E3%81%9F%E3%81%84%E3%81%A7%E3%81%99%E3%80%82"
   secondary_cta: GitHubでソースを見る
   secondary_cta_url: https://github.com/davidklan-png/dazbeez
   privacy_note: 実際のアプリはClerkで保護され、noindexに設定されています。このページの画面例はすべて合成データです。


### PR DESCRIPTION
Follow-up to #32. The splash page's primary CTA was a `mailto:` link; this repoints it to the contact form so requests land in a tracked channel instead of opening a raw email composer.

**Changes**
- `_data/projects/receipt_classification_matching.yml`: update `primary_cta_url` for both `splash` (EN) and `splash_ja` (JA) from `mailto:admin@dazbeez.com?...` to `https://dazbeez.com/contact?message=...`, pre-filling the walkthrough request.

No layout or logic changes — single data-file edit.

🤖 Generated with [Claude Code](https://claude.com/claude-code)